### PR TITLE
RP2040: Fix GCC 14 build break

### DIFF
--- a/rp2040-hello/CMakeLists.txt
+++ b/rp2040-hello/CMakeLists.txt
@@ -1,11 +1,14 @@
 cmake_minimum_required(VERSION 3.12)
 
 if (NOT PICO_SDK_PATH)
-    #    message(FATAL_ERROR "Path to Raspberry Pi Pico SDK not set. Use -DPICO_SDK_PATH=<path> to point to pico-sdk!")
+    message(STATUS "Using Pico-SDK bundled with examples repository. If you want different Pico-SDK pass -DPICO_SDK_PATH=<path> to CMake!")
+    set(PICO_SDK_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../pico-sdk)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${PICO_SDK_PATH}/external")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmrx/cmake")
+
+set(CMRX_MAP_FILE_WITH_EXTENSION TRUE)
 
 include(pico_sdk_import)
 


### PR DESCRIPTION
GCC 14 is a bit more strict towards bad programmer practices. Update examples to use newer kernel source code that fixes many of such occurrences.

Configure source code to explicitly use long map file name (ending with .elf.map) because that's what Pico-SDK does.

Automatically configure Pico-SDK path if not provided on CMake command line.