### PR TITLE
Feature: Add example of Linux build

### DIFF
--- a/linux-hello/CMakeLists.txt
+++ b/linux-hello/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.22)
+
+set(CMAKE_C_FLAGS_Debug "-ggdb3 -Wall -Wextra")
+
+project(cmrx-on-linux)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../cmrx/cmake)
+add_compile_definitions(-DCMRX_VERBOSE_API_NAMES=1)
+
+set(CMRX_ARCH linux)
+set(CMRX_HAL posix)
+
+include(CMRX)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+add_subdirectory(../cmrx ${CMAKE_BINARY_DIR}/cmrx)
+add_subdirectory(emu)
+add_subdirectory(src)
+
+add_firmware(linux-hello src/main.c)
+target_link_libraries(linux-hello cmrx)
+target_add_applications(linux-hello app uart uart_emu)

--- a/linux-hello/README.md
+++ b/linux-hello/README.md
@@ -1,0 +1,17 @@
+Linux CMRX example
+==================
+
+This is a short example that demonstrates how to use CMRX hosted environment that runs on Linux. In this example a simple UART emulation is created that connects to UNIX socket accessible from the outside world.
+
+There is a driver exposing RPC interface, that provides an interface to this device, (almost) completely unaware of the software-defined nature of the device.
+
+And there's an application that listens to whatever was sent on the UART and echoes is back, once received.
+
+Organization
+------------
+
+The code in `emu` subdirectory belongs to the emulated UART port. This code is not using any of CMRX services and is exposing only three objects:
+* _R() and _W() are functions that emulate read- and write-triggered device response. This is to ease driver implementation as automatic triggering of code execution done just by pure reading or writing a piece of memory is non-trivial and slow in Linux
+* UART0 is a variable that resembles register set of an UART peripheral. You can use above functions to read/write from/to this and trigger the emulated peripheral to act.
+
+All the remaining code in `src` uses CMRX and does not use code of the Linux platform at all. Code in subdirectories of directory `src` creates two processes. One of them is actually a driver. These are using CMRX services exclusively. The `main.c` file is a startup file that creates the instance of emulated UART, performs the early initialization of "hardware" and then starts-up the CMRX operating system.

--- a/linux-hello/emu/CMakeLists.txt
+++ b/linux-hello/emu/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(uart_emu STATIC emu.c)
+target_link_libraries(uart_emu stdlib phy_emu)

--- a/linux-hello/emu/emu.c
+++ b/linux-hello/emu/emu.c
@@ -1,0 +1,148 @@
+#include "uart.h"
+#include "emu_priv.h"
+#include "emu.h"
+
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <string.h>
+#include <unistd.h>
+#include <extra/emulator.h>
+
+#include <threads.h>
+
+#define UART_SOCK_FILE "uart0.sock"
+
+static int sock_fd = -1;
+
+static void uart_emu_write(volatile void * addr);
+static void uart_emu_read(const volatile void * addr);
+
+/* Create peripheral emulator instance. This instance will be called `uart_emu` */
+CMRX_PERIPHERAL_EMULATOR(UART_Device_t, uart_emu, uart_emu_read, uart_emu_write);
+
+static struct sockaddr_un uart_other_endpoint;
+static socklen_t uart_other_endpoint_len = sizeof(uart_other_endpoint);
+
+/** Emulated UART register write callback.
+ *
+ * If TXD register is written, then it will try to
+ * transmit the data.
+ *
+ * If CR register is written and bit RESET is set
+ * then peripheral is reset into default state.
+ */
+static void uart_emu_write(volatile void * addr)
+{
+    if (addr == &uart_emu.device.TXD)
+    {
+        uint8_t buff = *((uint8_t *) addr);
+        if (sock_fd == -1)
+        {
+            uart_emu.device_full.STS |= UART_STS_ERR;
+            return;
+        }
+
+        int ret = -1;
+
+        ret = sendto(sock_fd, &buff, sizeof(buff), 0, (struct sockaddr *)&uart_other_endpoint, uart_other_endpoint_len);
+        if (ret < 0) {
+            uart_emu.device_full.STS |= UART_STS_ERR;
+        }
+    } else {
+        if (addr == &uart_emu.device.CR)
+        {
+            uint32_t cr = *((uint32_t *) addr);
+
+            if (cr & UART_CR_RESET)
+            {
+                uart_emu.device_full.STS = UART_STS_TXRDY;
+                uart_emu.device_full.CR = 0;
+                uart_emu.device_full.RXD = 0;
+                uart_emu.device_full.TXD = 0;
+            }
+        }
+    }
+}
+
+/** Emulated UART register read callback.
+ *
+ * After data is read from the RXD register, the
+ * RXRDY flag is cleared.
+ */
+static void uart_emu_read(const volatile void * addr)
+{
+    // Clear the RX ready flag. This will be done slightly before
+    // the data is actually read but it doesn't matter as from the
+    // CMRX application's point of view it happend simultaneously.
+    if (addr == &uart_emu.device.RXD)
+    {
+        uart_emu.device.STS &= ~UART_STS_RXRDY;
+    }
+}
+
+/** Emulated UART instance application is seeing and can reference */
+UART_Device_t * UART0 = &uart_emu.device;
+
+/** Main emulator thread.
+ *
+ * This opens the UNIX domain socket outer world
+ * can interact with and then waits for data being received.
+ * Once data is received, it is put into RXD register, so application
+ * can read it and IRQ 15 is generated.
+ */
+int uart_emulation_main(void * nothing)
+{
+    (void) nothing;
+
+    struct sockaddr_un addr;
+    int ret;
+    unsigned char buff[1];
+    int ok = 1;
+    int len;
+
+    while (1) {
+        if ((sock_fd = socket(PF_UNIX, SOCK_DGRAM, 0)) < 0) {
+            ok = 0;
+        }
+
+        if (ok) {
+            memset(&addr, 0, sizeof(addr));
+            addr.sun_family = AF_UNIX;
+            strcpy(addr.sun_path, UART_SOCK_FILE);
+            unlink(UART_SOCK_FILE);
+            if (bind(sock_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+                ok = 0;
+            }
+        }
+
+        static struct sockaddr_un from;
+        static socklen_t fromlen = sizeof(from);
+        while ((len = recvfrom(sock_fd, buff, 1, 0, (struct sockaddr *)&from, &fromlen)) > 0) {
+            memcpy(&uart_other_endpoint, &from, sizeof(from));
+            // Signal that data is ready
+            uart_emu.device_full.STS |= UART_STS_RXRDY;
+            generate_interrupt(15);
+
+            // Drop constness
+            uart_emu.device_full.RXD = buff[0];
+        }
+
+
+        if (sock_fd >= 0) {
+            close(sock_fd);
+        }
+    }
+    return 0;
+}
+
+thrd_t emu_thread;
+
+/** Initialize the emulator.
+ *
+ * This will start the UART emulator thread.
+ */
+void uart_emulation_init()
+{
+    thrd_create(&emu_thread, uart_emulation_main, NULL);
+}

--- a/linux-hello/emu/emu.h
+++ b/linux-hello/emu/emu.h
@@ -1,0 +1,4 @@
+#pragma once
+
+/** Initialize UART emulator harness. Only callable before CMRX kernel is started */
+void uart_emulation_init();

--- a/linux-hello/emu/emu_priv.h
+++ b/linux-hello/emu/emu_priv.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "uart.h"
+
+/* Emulator-private header. Not for inclusion in the app */
+
+/** Private version of the peripheral register set.
+ * This is a private version of the peripheral register file.
+ * The layout of this set must be the same as the layout
+ * visible by the application. The only difference is that
+ * we can add/remove const here to reflect the peripheral's
+ * ability to access the register.
+ *
+ * E.g. the TXD register is writable from the CPU's point of view
+ * but is readable from the peripheral's POV. In reality, all registers
+ * are writable by the peripheral, if not anything else, then at
+ * least for resetting purposes.
+ */
+typedef struct {
+    volatile uint32_t CR;
+    volatile uint32_t RXD;
+    volatile uint32_t TXD;
+    volatile uint32_t STS;
+} Full_UART_Device_t;
+
+#if 0
+/** Guard to check if internal and external structures are the same. */
+_Static_assert(sizeof(UART_Device_t) == sizeof(UART_Emu_Device_t), "Internal and public types that describe emulated UART differ in size!");
+
+/** Internal structure of the emulator. _R and _W both call-in here. */
+typedef struct {
+    void (*emu_write_cb)(volatile void * addr);
+    void (*emu_read_cb)(const volatile void * addr);
+    union {
+        UART_Device_t device;
+        UART_Emu_Device_t device_full;
+    };
+} UART_Emulation_t;
+#endif

--- a/linux-hello/emu/uart.h
+++ b/linux-hello/emu/uart.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <extra/emulator/peripheral.h>
+
+/* Emulated minimalistic UART peripheral.
+ *
+ * This is an interface of UART peripheral that is emulated
+ * in software as CMRX ecosystem sees it.
+ *
+ * It presents a structure type that collects a few registers
+ * that this simple peripheral provides and two functions
+ * _R() and _W() which are used to simulate register read
+ * and write.
+ */
+
+#include <stdint.h>
+
+#define UART_STS_TXRDY      (1 << 0)
+#define UART_STS_RXRDY      (1 << 1)
+#define UART_STS_ERR        (1 << 2)
+
+#define UART_CR_RESET       (1 << 0)
+
+/** Type that describes emulated peripheral register layout.
+ */
+typedef struct {
+    volatile uint32_t CR;
+    volatile const uint32_t RXD;
+    volatile uint32_t TXD;
+    volatile uint32_t STS;
+} UART_Device_t;
+
+/** Instance of the peripheral in memory. Actual address
+ * doesn't matter now.
+ */
+extern UART_Device_t * UART0;
+
+
+#if 0
+/** Simulate register read.
+ *
+ * @param x address of peripheral register. May be 8-, 16- or 32-bits large
+ * @returns value of that register as provided by the peripheral
+ */
+#define _R(x)   _Generic((x), \
+uint8_t : _R8,\
+uint16_t : _R16,\
+uint32_t : _R32)(&x)
+
+/** Simulate register write.
+ *
+ * @param x address of peripheral register. May be 8-, 16- or 32-bits large
+ * @param y value to be written. Type must match the register size.
+ */
+#define _W(x, y)  _Generic((x), \
+uint8_t : _W8,\
+uint16_t : _W16,\
+uint32_t : _W32)(&x, y)
+
+uint8_t _R8(const volatile uint8_t * source);
+uint16_t _R16(const volatile uint16_t * source);
+uint32_t _R32(const volatile uint32_t * source);
+
+void _W8(volatile uint8_t * dest, uint8_t value);
+void _W16(volatile uint16_t * dest, uint16_t value);
+void _W32(volatile uint32_t * dest, uint32_t value);
+
+#endif

--- a/linux-hello/src/CMakeLists.txt
+++ b/linux-hello/src/CMakeLists.txt
@@ -1,0 +1,4 @@
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+add_subdirectory(uart_driver)
+add_subdirectory(app)

--- a/linux-hello/src/app/CMakeLists.txt
+++ b/linux-hello/src/app/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_application(app app.c)
+target_link_libraries(app stdlib)

--- a/linux-hello/src/app/app.c
+++ b/linux-hello/src/app/app.c
@@ -1,0 +1,24 @@
+#include <cmrx/application.h>
+#include <uart_driver/uart.h>
+#include <cmrx/ipc/rpc.h>
+
+#include <stdio.h>
+
+int app_main(void * data)
+{
+    (void) data;
+
+    while (1) {
+        printf("Quack\n");
+        uint8_t buffer;
+        buffer = rpc_call(&uart_device, read);
+        printf("Got data\n");
+        rpc_call(&uart_device, write, buffer);
+    }
+
+    return 0;
+}
+
+OS_APPLICATION_MMIO_RANGE(app, 0, 0);
+OS_APPLICATION(app);
+OS_THREAD_CREATE(app, app_main, NULL, 64);

--- a/linux-hello/src/main.c
+++ b/linux-hello/src/main.c
@@ -1,0 +1,43 @@
+#include <cmrx/cmrx.h>
+#include <cmrx/clock.h>
+#include "uart_driver/init.h"
+#include <emu/emu.h>
+#include <signal.h>
+#include <pthread.h>
+#include <stdio.h>
+
+void timing_provider_setup(unsigned timeout_ms);
+
+/* Disable reception of these signals globally.
+ * CMRX Linux port is using these signals to implement
+ * kernel features.
+ *
+ * These expect to be only serviced in the context of
+ * CMRX thread.
+ *
+ * By disabling it early - ideally as the very first thing
+ * that the program does - we ensure that only those threads
+ * which later enable these signals will really get them.
+ */
+void arch_early_init()
+{
+    sigset_t set;
+
+    sigemptyset(&set);
+    sigaddset(&set, SIGALRM);
+    sigaddset(&set, SIGUSR1);
+    sigaddset(&set, SIGUSR2);
+    sigaddset(&set, SIGURG);
+    pthread_sigmask(SIG_BLOCK, &set, NULL);
+}
+
+int main(int argc, char ** argv)
+{
+    arch_early_init();
+    uart_emulation_init();
+
+    uart_init();
+    timing_provider_setup(1000);
+    os_start();
+}
+

--- a/linux-hello/src/uart_driver/CMakeLists.txt
+++ b/linux-hello/src/uart_driver/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_application(uart driver.c init.c)
+target_link_libraries(uart stdlib)

--- a/linux-hello/src/uart_driver/driver.c
+++ b/linux-hello/src/uart_driver/driver.c
@@ -1,0 +1,71 @@
+#include "uart.h"
+#include <emu/uart.h>
+
+#include <cmrx/rpc/implementation.h>
+#include <cmrx/application.h>
+#include <cmrx/ipc/notify.h>
+#include <cmrx/ipc/isr.h>
+
+/** Handler of emulated IRQ signal.
+ *
+ * This function will be called asynchronously
+ * preempting whatever other code was running
+ * except of thread switcher which "disables
+ * interrupts".
+ *
+ * Drivers can trigger interrupts by using
+ * @ref generate_interrupt function.
+ *
+ * You can treat this function as if it was
+ * an interrupt handler on real hardware - it
+ * preempts all the non-interrupt code. It
+ * *can't* use system calls either, because it
+ * preempts even the kernel.
+ *
+ * You can only use functions in group of ISR
+ * API, which boils down to two functions:
+ *
+ * - isr_kill()
+ * - isr_notify_object()
+ *
+ * Other than that you can work with all the memory,
+ * but beware - while this handler is running all the
+ * normal system services are disabled, so you better
+ * don't do any long-term work in here.
+ */
+void IRQ_15()
+{
+    isr_notify_object(&uart_device);
+}
+
+IMPLEMENTATION_OF(struct UART, struct UARTVtable);
+
+static uint8_t uart_read(INSTANCE(this))
+{
+    while (!(_R(UART0, STS) & UART_STS_RXRDY))
+    {
+        wait_for_object(&uart_device, 0);
+    }
+    return _R(UART0, RXD);
+}
+
+static void uart_write(INSTANCE(this), uint8_t data)
+{
+    while (!(_R(UART0, STS) & UART_STS_TXRDY))
+    {
+        wait_for_object(&uart_device, 0);
+    }
+    return _W(UART0, TXD, data);
+}
+
+VTABLE struct UARTVtable uart_vtable = {
+    &uart_read,
+    &uart_write
+};
+
+struct UART uart_device = {
+    &uart_vtable
+};
+
+OS_APPLICATION_MMIO_RANGE(uart, 0, 0);
+OS_APPLICATION(uart);

--- a/linux-hello/src/uart_driver/init.c
+++ b/linux-hello/src/uart_driver/init.c
@@ -1,0 +1,10 @@
+#include "init.h"
+#include <emu/uart.h>
+
+void uart_init()
+{
+    /* Intentionally left empty. Peripheral
+     * is so simple it doesn't need any
+     * initialization. */
+    _W(UART0, CR, UART_CR_RESET);
+}

--- a/linux-hello/src/uart_driver/init.h
+++ b/linux-hello/src/uart_driver/init.h
@@ -1,0 +1,13 @@
+#pragma once
+
+/** Early initialization of the UART driver.
+ *
+ * This routine runs before the CMRX kernel has been started up
+ * so it has full hardware access. It can be used to configure
+ * the peripheral, such as switching pins into AF mode, enabling
+ * clocks, power, etc.
+ *
+ * It is meant for one-time post-boot initialization which is dependant
+ * on the hardware config, rather than application configuration.
+ */
+void uart_init();

--- a/linux-hello/src/uart_driver/uart.h
+++ b/linux-hello/src/uart_driver/uart.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <stdint.h>
+#include <cmrx/rpc/interface.h>
+
+struct UARTVtable {
+    uint8_t (*read)(INSTANCE(this));
+    void (*write)(INSTANCE(thuis), uint8_t data);
+};
+
+struct UART {
+    const struct UARTVtable * vtable;
+    /* This peripheral has no data */
+};
+
+extern struct UART uart_device;


### PR DESCRIPTION
The Linux build example showcases how to create a Linux-hosted build of CMRX which may be suitable for testing and/or development.

The example contains of three main parts:
- high level application which is just a simple UART echo. It reads data character by character and whenever something is received, it sends it back.
- UART driver for emulated peripheral. This driver is talking to peripheral memory-mapped registers. It registers IRQ handler that receives interrupt from peripheral, that data are ready for reception.
- Emulation of the UART peripheral, that provides access to the other end of the peripheral via UNIX datagram socket. Whenever something is received via the socket, emulator generates IRQ which is dispatched to the running system.

Emulated peripheral is created using lightweight peripheral emulation framework shipped with CMRX.

Driver is using peripheral register file to read/write data from/to the peripheral. This access looks almost identical to real hardware with only minor modifications.

Application talks to the driver via RPC interface, the same way it would use on the real hardware.

Application and driver are just standard CMRX applications while the UART emulator runs "outside" CMRX, using just the API to generate interrupt. Other than that, the emulator is relying on Linux APIs to do its work.